### PR TITLE
Add Serilog-based logging infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Key decisions:
 - **TFM**: `net10.0` (not `net10.0-windows`) — buildable on macOS; switch to `-windows` when Windows APIs are needed
 - **Central Package Management**: all NuGet package versions are pinned in `Directory.Packages.props`
 - **Shared MSBuild settings**: `Directory.Build.props` sets nullable, implicit usings, and warnings-as-errors for all projects
+- **Logging**: Serilog is used as the logging backend (infrastructure only — wired in `Program.cs` via `UseSerilog()`). All application code uses `Microsoft.Extensions.Logging.ILogger<T>`. Structured event IDs are defined in `src/ArcadeCabinetSwitcher/LogEvents.cs`. Sinks (Console, File, Windows Event Log) are configured in `appsettings.json` under the `Serilog` key.
 
 ## Tech Stack
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,14 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
   </ItemGroup>
 
+  <ItemGroup Label="Logging">
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.EventLog" Version="4.0.0" />
+  </ItemGroup>
+
   <ItemGroup Label="Test">
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ dotnet run --project src/ArcadeCabinetSwitcher
 
 Configuration is stored in a JSON file. Each profile specifies the commands to run and the joystick combo used to switch to it. See [SPEC.md](SPEC.md) for the full configuration format and examples.
 
+## Logging
+
+Logging is configured in `appsettings.json` under the `Serilog` key. By default, events are written to the **console** and to a **rolling daily log file** under `logs/`.
+
+### Enable Windows Event Log
+
+To also write to the Windows Event Log, first create the event source once (run as Administrator):
+
+```powershell
+New-EventLog -LogName Application -Source "ArcadeCabinetSwitcher"
+```
+
+Then uncomment the `EventLog` sink block in `appsettings.json`.
+
+### Change the minimum log level
+
+Edit the `MinimumLevel.Default` value in `appsettings.json` (e.g., `"Debug"` for verbose output).
+
 ## License
 
 This project is licensed under the terms of the [LICENSE](LICENSE) file.

--- a/src/ArcadeCabinetSwitcher/ArcadeCabinetSwitcher.csproj
+++ b/src/ArcadeCabinetSwitcher/ArcadeCabinetSwitcher.csproj
@@ -8,6 +8,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Serilog.Extensions.Hosting" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Serilog.Sinks.EventLog" />
   </ItemGroup>
 
 </Project>

--- a/src/ArcadeCabinetSwitcher/LogEvents.cs
+++ b/src/ArcadeCabinetSwitcher/LogEvents.cs
@@ -1,0 +1,41 @@
+namespace ArcadeCabinetSwitcher;
+
+/// <summary>
+/// Structured event ID constants for all FR-7.2 log events.
+/// </summary>
+/// <remarks>
+/// Ranges:
+///   1000–1099  Service lifecycle (start, stop)
+///   2000–2099  Configuration (loaded, invalid, missing)
+///   3000–3099  Profile switching (switch started, completed)
+///   4000–4099  Process management (launched, terminated, failed)
+///   5000–5099  Input detection (combo detected, input error)
+///   9000–9099  Errors (unexpected exceptions)
+/// </remarks>
+public static class LogEvents
+{
+    // Service lifecycle
+    public static readonly EventId ServiceStarting = new(1000, nameof(ServiceStarting));
+    public static readonly EventId ServiceStopping = new(1001, nameof(ServiceStopping));
+
+    // Configuration
+    public static readonly EventId ConfigurationLoaded = new(2000, nameof(ConfigurationLoaded));
+    public static readonly EventId ConfigurationInvalid = new(2001, nameof(ConfigurationInvalid));
+    public static readonly EventId ConfigurationMissing = new(2002, nameof(ConfigurationMissing));
+
+    // Profile switching
+    public static readonly EventId ProfileSwitchStarted = new(3000, nameof(ProfileSwitchStarted));
+    public static readonly EventId ProfileSwitchCompleted = new(3001, nameof(ProfileSwitchCompleted));
+
+    // Process management
+    public static readonly EventId ProcessLaunched = new(4000, nameof(ProcessLaunched));
+    public static readonly EventId ProcessTerminated = new(4001, nameof(ProcessTerminated));
+    public static readonly EventId ProcessTerminationFailed = new(4002, nameof(ProcessTerminationFailed));
+
+    // Input detection
+    public static readonly EventId InputComboDetected = new(5000, nameof(InputComboDetected));
+    public static readonly EventId InputError = new(5001, nameof(InputError));
+
+    // Errors
+    public static readonly EventId UnexpectedException = new(9000, nameof(UnexpectedException));
+}

--- a/src/ArcadeCabinetSwitcher/Program.cs
+++ b/src/ArcadeCabinetSwitcher/Program.cs
@@ -1,4 +1,5 @@
 using ArcadeCabinetSwitcher;
+using Serilog;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddWindowsService(options =>
@@ -6,6 +7,9 @@ builder.Services.AddWindowsService(options =>
     options.ServiceName = "ArcadeCabinetSwitcher";
 });
 builder.Services.AddHostedService<Worker>();
+
+builder.Services.AddSerilog((_, lc) =>
+    lc.ReadFrom.Configuration(builder.Configuration));
 
 var host = builder.Build();
 host.Run();

--- a/src/ArcadeCabinetSwitcher/Worker.cs
+++ b/src/ArcadeCabinetSwitcher/Worker.cs
@@ -4,7 +4,7 @@ public class Worker(ILogger<Worker> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        logger.LogInformation("Arcade Cabinet App Switcher starting");
+        logger.LogInformation(LogEvents.ServiceStarting, "Arcade Cabinet App Switcher starting");
 
         // TODO (#5): Load configuration via IConfigurationLoader
         // TODO (#6): Start input handler via IInputHandler.StartAsync
@@ -12,6 +12,6 @@ public class Worker(ILogger<Worker> logger) : BackgroundService
 
         await Task.Delay(Timeout.Infinite, stoppingToken);
 
-        logger.LogInformation("Arcade Cabinet App Switcher stopping");
+        logger.LogInformation(LogEvents.ServiceStopping, "Arcade Cabinet App Switcher stopping");
     }
 }

--- a/src/ArcadeCabinetSwitcher/appsettings.json
+++ b/src/ArcadeCabinetSwitcher/appsettings.json
@@ -1,8 +1,40 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+        }
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/arcade-cabinet-switcher.log",
+          "rollingInterval": "Day",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}"
+        }
+      }
+      // To enable Windows Event Log output, uncomment and configure the block below.
+      // Requires the service to run on Windows with an existing event source.
+      // Create the event source once (as Administrator):
+      //   New-EventLog -LogName Application -Source "ArcadeCabinetSwitcher"
+      //
+      // ,{
+      //   "Name": "EventLog",
+      //   "Args": {
+      //     "source": "ArcadeCabinetSwitcher",
+      //     "logName": "Application"
+      //   }
+      // }
+    ],
+    "Enrich": [ "FromLogContext" ]
   }
 }

--- a/tests/ArcadeCabinetSwitcher.Tests/LogEventsTests.cs
+++ b/tests/ArcadeCabinetSwitcher.Tests/LogEventsTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+
+namespace ArcadeCabinetSwitcher.Tests;
+
+[TestClass]
+public class LogEventsTests
+{
+    [TestMethod]
+    public void LogEvents_AllEventIds_AreUnique()
+    {
+        var fields = typeof(LogEvents)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.FieldType == typeof(EventId))
+            .Select(f => (EventId)f.GetValue(null)!)
+            .ToList();
+
+        var ids = fields.Select(e => e.Id).ToList();
+        var duplicates = ids.GroupBy(id => id).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+
+        Assert.AreEqual(0, duplicates.Count,
+            $"Duplicate EventId values found: {string.Join(", ", duplicates)}");
+    }
+
+    [TestMethod]
+    public void LogEvents_AllEventIds_HaveNames()
+    {
+        var fields = typeof(LogEvents)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.FieldType == typeof(EventId))
+            .Select(f => (EventId)f.GetValue(null)!)
+            .ToList();
+
+        var unnamed = fields.Where(e => string.IsNullOrEmpty(e.Name)).ToList();
+
+        Assert.AreEqual(0, unnamed.Count,
+            $"{unnamed.Count} EventId(s) have no name.");
+    }
+}


### PR DESCRIPTION
## Summary

- Wires Serilog as the `ILogger<T>` backend (infrastructure-only in `Program.cs` via `AddSerilog()`); all application code continues using `Microsoft.Extensions.Logging.ILogger<T>`
- Console and rolling daily file sinks enabled by default; Windows Event Log sink documented as opt-in in `appsettings.json`
- Defines structured `EventId` constants in `LogEvents.cs` covering all FR-7.2 event categories (service lifecycle, configuration, profile switching, process management, input detection, errors)
- Updates `Worker.cs` to use the new event IDs on its start/stop log calls
- Adds `LogEventsTests.cs` with uniqueness and naming assertions for all event IDs

## Test plan

- [x] `dotnet build` — clean build, 0 warnings (TreatWarningsAsErrors is on)
- [x] `dotnet test` — all 3 tests pass (1 existing + 2 new)
- [x] `dotnet run --project src/ArcadeCabinetSwitcher` — service starts, logs appear on console and in `logs/` directory with expected format
- [ ] On Windows: uncomment Event Log sink in `appsettings.json`, verify events appear in Windows Event Viewer

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)