### PR TITLE
Implement profile switching orchestration

### DIFF
--- a/src/ArcadeCabinetSwitcher/LogEvents.cs
+++ b/src/ArcadeCabinetSwitcher/LogEvents.cs
@@ -26,6 +26,10 @@ public static class LogEvents
     // Profile switching
     public static readonly EventId ProfileSwitchStarted = new(3000, nameof(ProfileSwitchStarted));
     public static readonly EventId ProfileSwitchCompleted = new(3001, nameof(ProfileSwitchCompleted));
+    public static readonly EventId ProfileSwitchIgnored = new(3002, nameof(ProfileSwitchIgnored));
+    public static readonly EventId ProfileSwitchFailed = new(3003, nameof(ProfileSwitchFailed));
+    public static readonly EventId DefaultProfileLaunched = new(3004, nameof(DefaultProfileLaunched));
+    public static readonly EventId SpecialActionExecuted = new(3005, nameof(SpecialActionExecuted));
 
     // Process management
     public static readonly EventId ProcessLaunched = new(4000, nameof(ProcessLaunched));

--- a/src/ArcadeCabinetSwitcher/ProcessManagement/ISystemActionHandler.cs
+++ b/src/ArcadeCabinetSwitcher/ProcessManagement/ISystemActionHandler.cs
@@ -1,0 +1,14 @@
+using ArcadeCabinetSwitcher.Configuration;
+
+namespace ArcadeCabinetSwitcher.ProcessManagement;
+
+/// <summary>
+/// Executes special system actions such as reboot and shutdown.
+/// </summary>
+public interface ISystemActionHandler
+{
+    /// <summary>
+    /// Executes the given system action.
+    /// </summary>
+    Task ExecuteAsync(ProfileAction action, CancellationToken cancellationToken);
+}

--- a/src/ArcadeCabinetSwitcher/ProcessManagement/SystemActionHandler.cs
+++ b/src/ArcadeCabinetSwitcher/ProcessManagement/SystemActionHandler.cs
@@ -1,0 +1,21 @@
+using ArcadeCabinetSwitcher.Configuration;
+
+namespace ArcadeCabinetSwitcher.ProcessManagement;
+
+public sealed class SystemActionHandler(ILogger<SystemActionHandler> logger) : ISystemActionHandler
+{
+    public Task ExecuteAsync(ProfileAction action, CancellationToken cancellationToken)
+    {
+        var (command, args) = action switch
+        {
+            ProfileAction.Reboot => ("shutdown", "/r /t 0"),
+            ProfileAction.Shutdown => ("shutdown", "/s /t 0"),
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+        };
+
+        logger.LogInformation(LogEvents.SpecialActionExecuted, "Executing system action: {Action}", action);
+
+        System.Diagnostics.Process.Start(command, args);
+        return Task.CompletedTask;
+    }
+}

--- a/src/ArcadeCabinetSwitcher/Program.cs
+++ b/src/ArcadeCabinetSwitcher/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddWindowsService(options =>
 builder.Services.AddSingleton<IConfigurationLoader, ConfigurationLoader>();
 builder.Services.AddSingleton<IProcessLauncher, SystemProcessLauncher>();
 builder.Services.AddSingleton<IProcessManager, ProcessManager>();
+builder.Services.AddSingleton<ISystemActionHandler, SystemActionHandler>();
 builder.Services.AddSingleton<IJoystickReader, SdlJoystickReader>();
 builder.Services.AddSingleton<IInputHandler, InputHandler>();
 builder.Services.AddHostedService<Worker>();

--- a/src/ArcadeCabinetSwitcher/Worker.cs
+++ b/src/ArcadeCabinetSwitcher/Worker.cs
@@ -1,13 +1,19 @@
 using ArcadeCabinetSwitcher.Configuration;
 using ArcadeCabinetSwitcher.Input;
+using ArcadeCabinetSwitcher.ProcessManagement;
 
 namespace ArcadeCabinetSwitcher;
 
 public class Worker(
     ILogger<Worker> logger,
     IConfigurationLoader configurationLoader,
-    IInputHandler inputHandler) : BackgroundService
+    IInputHandler inputHandler,
+    IProcessManager processManager,
+    ISystemActionHandler systemActionHandler) : BackgroundService
 {
+    private string? _activeProfileName;
+    private int _switching; // 0 = idle, 1 = in progress
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         logger.LogInformation(LogEvents.ServiceStarting, "Arcade Cabinet App Switcher starting");
@@ -15,15 +21,79 @@ public class Worker(
         var config = configurationLoader.Load();
 
         inputHandler.ProfileSwitchRequested += (_, profileName) =>
-            logger.LogInformation(LogEvents.ProfileSwitchStarted,
-                "Profile switch requested: {ProfileName}", profileName);
+            OnProfileSwitchRequested(profileName, config, stoppingToken);
 
         await inputHandler.StartAsync(config, stoppingToken);
 
-        // TODO (#8): Wire up profile switch requests to IProcessManager (using config)
+        var defaultProfile = config.Profiles.FirstOrDefault(p =>
+            string.Equals(p.Name, config.DefaultProfile, StringComparison.OrdinalIgnoreCase));
+
+        if (defaultProfile is not null)
+        {
+            logger.LogInformation(LogEvents.DefaultProfileLaunched,
+                "Launching default profile: {ProfileName}", defaultProfile.Name);
+            await processManager.LaunchProfileAsync(defaultProfile, stoppingToken);
+            _activeProfileName = defaultProfile.Name;
+        }
+        else
+        {
+            logger.LogWarning(LogEvents.ProfileSwitchFailed,
+                "Default profile '{ProfileName}' not found in configuration", config.DefaultProfile);
+        }
 
         await Task.Delay(Timeout.Infinite, stoppingToken);
 
         logger.LogInformation(LogEvents.ServiceStopping, "Arcade Cabinet App Switcher stopping");
+    }
+
+    private async void OnProfileSwitchRequested(string profileName, AppSwitcherConfig config, CancellationToken cancellationToken)
+    {
+        if (Interlocked.CompareExchange(ref _switching, 1, 0) != 0)
+        {
+            logger.LogInformation(LogEvents.ProfileSwitchIgnored,
+                "Profile switch to '{ProfileName}' ignored — switch already in progress", profileName);
+            return;
+        }
+
+        try
+        {
+            var target = config.Profiles.FirstOrDefault(p =>
+                string.Equals(p.Name, profileName, StringComparison.OrdinalIgnoreCase));
+
+            if (target is null)
+            {
+                logger.LogError(LogEvents.ProfileSwitchFailed,
+                    "Profile switch requested for unknown profile '{ProfileName}'", profileName);
+                return;
+            }
+
+            logger.LogInformation(LogEvents.ProfileSwitchStarted,
+                "Switching to profile: {ProfileName}", profileName);
+
+            await processManager.TerminateActiveProfileAsync(cancellationToken);
+
+            if (target.Action is { } action)
+            {
+                await systemActionHandler.ExecuteAsync(action, cancellationToken);
+            }
+            else
+            {
+                await processManager.LaunchProfileAsync(target, cancellationToken);
+            }
+
+            _activeProfileName = target.Name;
+
+            logger.LogInformation(LogEvents.ProfileSwitchCompleted,
+                "Profile switch to '{ProfileName}' completed", profileName);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(LogEvents.ProfileSwitchFailed, ex,
+                "Profile switch to '{ProfileName}' failed", profileName);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _switching, 0);
+        }
     }
 }

--- a/tests/ArcadeCabinetSwitcher.Tests/WorkerTests.cs
+++ b/tests/ArcadeCabinetSwitcher.Tests/WorkerTests.cs
@@ -1,5 +1,6 @@
 using ArcadeCabinetSwitcher.Configuration;
 using ArcadeCabinetSwitcher.Input;
+using ArcadeCabinetSwitcher.ProcessManagement;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -8,52 +9,276 @@ namespace ArcadeCabinetSwitcher.Tests;
 [TestClass]
 public class WorkerTests
 {
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static ProfileConfig MakeProfile(string name, string[]? commands = null, ProfileAction? action = null) =>
+        new()
+        {
+            Name = name,
+            Commands = commands,
+            Action = action,
+            SwitchCombo = new SwitchComboConfig { Buttons = ["B1"], HoldDurationSeconds = 3 }
+        };
+
+    private static AppSwitcherConfig MakeConfig(string defaultProfile, params ProfileConfig[] profiles) =>
+        new() { DefaultProfile = defaultProfile, Profiles = profiles };
+
+    private static Worker MakeWorker(
+        AppSwitcherConfig config,
+        out StubInputHandler inputHandler,
+        out SpyProcessManager processManager,
+        out SpySystemActionHandler systemActionHandler)
+    {
+        inputHandler = new StubInputHandler();
+        processManager = new SpyProcessManager();
+        systemActionHandler = new SpySystemActionHandler();
+
+        return new Worker(
+            NullLogger<Worker>.Instance,
+            new StubConfigurationLoader(config),
+            inputHandler,
+            processManager,
+            systemActionHandler);
+    }
+
+    // ── startup ───────────────────────────────────────────────────────────────
+
     [TestMethod]
     public async Task Worker_StartsAndStops_WithoutError()
     {
-        var worker = new Worker(
-            NullLogger<Worker>.Instance,
-            new StubConfigurationLoader(),
-            new StubInputHandler());
+        var config = MakeConfig("default", MakeProfile("default", ["notepad.exe"]));
+        var worker = MakeWorker(config, out _, out _, out _);
         using var cts = new CancellationTokenSource();
 
         var executeTask = worker.StartAsync(cts.Token);
-
         await cts.CancelAsync();
         await worker.StopAsync(CancellationToken.None);
 
         Assert.IsTrue(executeTask.IsCompleted);
     }
 
-    private sealed class StubConfigurationLoader : IConfigurationLoader
+    [TestMethod]
+    public async Task Worker_LaunchesDefaultProfile_OnStartup()
     {
-        public AppSwitcherConfig Load() => new()
-        {
-            DefaultProfile = "default",
-            Profiles =
-            [
-                new ProfileConfig
-                {
-                    Name = "default",
-                    Commands = ["notepad.exe"],
-                    SwitchCombo = new SwitchComboConfig
-                    {
-                        Buttons = ["Button1"],
-                        HoldDurationSeconds = 3
-                    }
-                }
-            ]
-        };
+        var config = MakeConfig("game1",
+            MakeProfile("game1", ["game.exe"]),
+            MakeProfile("menu", ["menu.exe"]));
+        var worker = MakeWorker(config, out _, out var pm, out _);
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, pm.LaunchedProfiles.Count);
+        Assert.AreEqual("game1", pm.LaunchedProfiles[0]);
+    }
+
+    [TestMethod]
+    public async Task Worker_DefaultProfileNotFound_DoesNotCrash()
+    {
+        var config = MakeConfig("missing", MakeProfile("other", ["app.exe"]));
+        var worker = MakeWorker(config, out _, out var pm, out _);
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(0, pm.LaunchedProfiles.Count);
+    }
+
+    // ── profile switch ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ProfileSwitch_TerminatesActiveAndLaunchesNewProfile()
+    {
+        var config = MakeConfig("game1",
+            MakeProfile("game1", ["game.exe"]),
+            MakeProfile("menu", ["menu.exe"]));
+        var worker = MakeWorker(config, out var ih, out var pm, out _);
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+        await ih.WhenStarted;
+
+        ih.RaiseProfileSwitchRequested("menu");
+        await Task.Delay(50); // let async void complete
+
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, pm.TerminateCallCount);
+        Assert.AreEqual(2, pm.LaunchedProfiles.Count);
+        Assert.AreEqual("menu", pm.LaunchedProfiles[1]);
+    }
+
+    [TestMethod]
+    public async Task ProfileSwitch_SpecialAction_CallsSystemActionHandler()
+    {
+        var config = MakeConfig("game1",
+            MakeProfile("game1", ["game.exe"]),
+            MakeProfile("reboot-profile", action: ProfileAction.Reboot));
+        var worker = MakeWorker(config, out var ih, out var pm, out var sa);
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+        await ih.WhenStarted;
+
+        ih.RaiseProfileSwitchRequested("reboot-profile");
+        await Task.Delay(50);
+
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, pm.TerminateCallCount);
+        Assert.AreEqual(1, sa.ExecutedActions.Count);
+        Assert.AreEqual(ProfileAction.Reboot, sa.ExecutedActions[0]);
+        // LaunchProfileAsync should NOT have been called for the action profile
+        Assert.AreEqual(1, pm.LaunchedProfiles.Count); // only the default
+    }
+
+    [TestMethod]
+    public async Task ProfileSwitch_UnknownProfile_LogsErrorAndDoesNotCrash()
+    {
+        var config = MakeConfig("game1", MakeProfile("game1", ["game.exe"]));
+        var worker = MakeWorker(config, out var ih, out var pm, out _);
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+        await ih.WhenStarted;
+
+        ih.RaiseProfileSwitchRequested("does-not-exist");
+        await Task.Delay(50);
+
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(0, pm.TerminateCallCount);
+    }
+
+    [TestMethod]
+    public async Task ProfileSwitch_ConcurrentRequests_SecondIsIgnored()
+    {
+        var config = MakeConfig("game1",
+            MakeProfile("game1", ["game.exe"]),
+            MakeProfile("menu", ["menu.exe"]));
+
+        var blockingPm = new BlockingProcessManager();
+        var ih = new StubInputHandler();
+        var worker = new Worker(
+            NullLogger<Worker>.Instance,
+            new StubConfigurationLoader(config),
+            ih,
+            blockingPm,
+            new SpySystemActionHandler());
+
+        using var cts = new CancellationTokenSource();
+        await worker.StartAsync(cts.Token);
+        await ih.WhenStarted; // wait for subscription to be set up + default launch
+
+        blockingPm.Block(); // next TerminateActiveProfileAsync will hang
+
+        ih.RaiseProfileSwitchRequested("menu"); // first switch — will block
+        await Task.Delay(20);
+
+        ih.RaiseProfileSwitchRequested("menu"); // second switch — should be ignored
+        await Task.Delay(20);
+
+        blockingPm.Unblock();
+        await Task.Delay(50);
+
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, blockingPm.TerminateCallCount, "Second switch should have been ignored");
+    }
+
+    // ── stubs / spies ─────────────────────────────────────────────────────────
+
+    private sealed class StubConfigurationLoader(AppSwitcherConfig config) : IConfigurationLoader
+    {
+        public AppSwitcherConfig Load() => config;
     }
 
     private sealed class StubInputHandler : IInputHandler
     {
-        public event EventHandler<string>? ProfileSwitchRequested { add { } remove { } }
+        private readonly TaskCompletionSource _startedTcs = new();
+
+        public event EventHandler<string>? ProfileSwitchRequested;
+
+        /// <summary>Completes when the Worker calls StartAsync (i.e., the event subscription is set up).</summary>
+        public Task WhenStarted => _startedTcs.Task;
+
+        public void RaiseProfileSwitchRequested(string profileName) =>
+            ProfileSwitchRequested?.Invoke(this, profileName);
 
         public Task StartAsync(AppSwitcherConfig config, CancellationToken cancellationToken)
-            => Task.CompletedTask;
+        {
+            _startedTcs.TrySetResult();
+            return Task.CompletedTask;
+        }
 
         public Task StopAsync(CancellationToken cancellationToken)
             => Task.CompletedTask;
+    }
+
+    private sealed class SpyProcessManager : IProcessManager
+    {
+        private readonly List<string> _launchedProfiles = [];
+
+        public IReadOnlyList<string> LaunchedProfiles => _launchedProfiles;
+        public int TerminateCallCount { get; private set; }
+
+        public Task LaunchProfileAsync(ProfileConfig profile, CancellationToken cancellationToken)
+        {
+            _launchedProfiles.Add(profile.Name);
+            return Task.CompletedTask;
+        }
+
+        public Task TerminateActiveProfileAsync(CancellationToken cancellationToken)
+        {
+            TerminateCallCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SpySystemActionHandler : ISystemActionHandler
+    {
+        private readonly List<ProfileAction> _executedActions = [];
+        public IReadOnlyList<ProfileAction> ExecutedActions => _executedActions;
+
+        public Task ExecuteAsync(ProfileAction action, CancellationToken cancellationToken)
+        {
+            _executedActions.Add(action);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// A process manager whose TerminateActiveProfileAsync can be blocked to simulate a long-running switch.
+    /// </summary>
+    private sealed class BlockingProcessManager : IProcessManager
+    {
+        private readonly List<string> _launchedProfiles = [];
+        private TaskCompletionSource? _gate;
+
+        public int TerminateCallCount { get; private set; }
+
+        public void Block() => _gate = new TaskCompletionSource();
+        public void Unblock() => _gate?.TrySetResult();
+
+        public Task LaunchProfileAsync(ProfileConfig profile, CancellationToken cancellationToken)
+        {
+            _launchedProfiles.Add(profile.Name);
+            return Task.CompletedTask;
+        }
+
+        public async Task TerminateActiveProfileAsync(CancellationToken cancellationToken)
+        {
+            TerminateCallCount++;
+            if (_gate is { } gate)
+                await gate.Task;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Wires `IProcessManager` and `ISystemActionHandler` into `Worker`, replacing the TODO placeholder with full orchestration logic
- Launches the default profile on startup
- Handles `ProfileSwitchRequested`: terminates the active profile, then either launches the new profile or executes a system action (reboot/shutdown)
- Prevents concurrent switches using an `Interlocked` flag
- Adds `ISystemActionHandler` / `SystemActionHandler` for reboot/shutdown via `shutdown /r /t 0` and `shutdown /s /t 0`
- Adds four new log event IDs (3002–3005)
- Adds `WorkerTests` covering startup, switching, action profiles, unknown profiles, and concurrency

## Test plan

- [x] `dotnet build` — no errors or warnings
- [x] `dotnet test` — all new and existing tests pass (pre-existing SDL joystick test failure unrelated)
- [x] Verified test synchronization: used `ih.WhenStarted` signal to handle .NET 10 `BackgroundService` async startup

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)