### PR TITLE
Add release workflow and NuGet caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore dependencies
         run: dotnet restore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Test
+        run: dotnet test --configuration Release --logger "console;verbosity=normal" --filter "TestCategory!=Integration"
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish win-x64
+        run: >
+          dotnet publish src/ArcadeCabinetSwitcher/ArcadeCabinetSwitcher.csproj
+          --configuration Release
+          --runtime win-x64
+          --self-contained true
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          --output publish/win-x64
+
+      - name: Zip release asset
+        run: |
+          cd publish/win-x64
+          zip -r "../../ArcadeCabinetSwitcher-${{ steps.version.outputs.VERSION }}-win-x64.zip" .
+
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh release upload "${{ github.ref_name }}"
+          "ArcadeCabinetSwitcher-${{ steps.version.outputs.VERSION }}-win-x64.zip"
+          --clobber


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` triggered on GitHub Release published: builds a self-contained win-x64 single-file executable and uploads it as a zipped release asset
- Adds NuGet package caching (`actions/cache@v4`) to both CI and release workflows

## Test plan
- [ ] Verify CI passes on this PR (NuGet cache step works)
- [ ] After merge, create a GitHub Release with tag `v0.1.0` and verify the release asset `ArcadeCabinetSwitcher-0.1.0-win-x64.zip` is attached

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)