### PR TITLE
Implement graceful shutdown and document Windows service configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ Each profile specifies either the commands to run or a special action (`reboot`/
 
 See [SPEC.md](SPEC.md) for the full configuration format and validation rules.
 
+## Service Configuration (Windows)
+
+After installing the service, two additional configuration steps are required (run as Administrator):
+
+### Recovery Policy (FR-4.3)
+
+Configure automatic recovery so the service restarts on failure:
+
+```cmd
+sc.exe failure ArcadeCabinetSwitcher reset= 86400 actions= restart/5000/restart/5000/reboot/5000
+```
+
+This restarts the service after the first and second failures (with a 5-second delay) and reboots the machine after the third failure within a 24-hour window.
+
+### User Account (FR-4.2)
+
+By default, Windows services run as `LocalSystem`. To run as a specific user (e.g., the auto-login arcade account):
+
+```cmd
+sc.exe config ArcadeCabinetSwitcher obj= "DOMAIN\username" password= "password"
+```
+
+> **Note:** Issue #10 (MSI installer) will automate both of these steps as part of the installation wizard.
+
 ## Logging
 
 Logging is configured in `appsettings.json` under the `Serilog` key. By default, events are written to the **console** and to a **rolling daily log file** under `logs/`.

--- a/src/ArcadeCabinetSwitcher/Worker.cs
+++ b/src/ArcadeCabinetSwitcher/Worker.cs
@@ -42,8 +42,14 @@ public class Worker(
         }
 
         await Task.Delay(Timeout.Infinite, stoppingToken);
+    }
 
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
         logger.LogInformation(LogEvents.ServiceStopping, "Arcade Cabinet App Switcher stopping");
+        await inputHandler.StopAsync(cancellationToken);
+        await processManager.TerminateActiveProfileAsync(cancellationToken);
+        await base.StopAsync(cancellationToken);
     }
 
     private async void OnProfileSwitchRequested(string profileName, AppSwitcherConfig config, CancellationToken cancellationToken)

--- a/tests/ArcadeCabinetSwitcher.Tests/WorkerTests.cs
+++ b/tests/ArcadeCabinetSwitcher.Tests/WorkerTests.cs
@@ -108,7 +108,7 @@ public class WorkerTests
         await cts.CancelAsync();
         await worker.StopAsync(CancellationToken.None);
 
-        Assert.AreEqual(1, pm.TerminateCallCount);
+        Assert.AreEqual(2, pm.TerminateCallCount); // 1 from profile switch + 1 from StopAsync
         Assert.AreEqual(2, pm.LaunchedProfiles.Count);
         Assert.AreEqual("menu", pm.LaunchedProfiles[1]);
     }
@@ -131,7 +131,7 @@ public class WorkerTests
         await cts.CancelAsync();
         await worker.StopAsync(CancellationToken.None);
 
-        Assert.AreEqual(1, pm.TerminateCallCount);
+        Assert.AreEqual(2, pm.TerminateCallCount); // 1 from profile switch + 1 from StopAsync
         Assert.AreEqual(1, sa.ExecutedActions.Count);
         Assert.AreEqual(ProfileAction.Reboot, sa.ExecutedActions[0]);
         // LaunchProfileAsync should NOT have been called for the action profile
@@ -154,7 +154,7 @@ public class WorkerTests
         await cts.CancelAsync();
         await worker.StopAsync(CancellationToken.None);
 
-        Assert.AreEqual(0, pm.TerminateCallCount);
+        Assert.AreEqual(1, pm.TerminateCallCount); // 0 from failed switch + 1 from StopAsync
     }
 
     [TestMethod]
@@ -191,7 +191,37 @@ public class WorkerTests
         await cts.CancelAsync();
         await worker.StopAsync(CancellationToken.None);
 
-        Assert.AreEqual(1, blockingPm.TerminateCallCount, "Second switch should have been ignored");
+        Assert.AreEqual(2, blockingPm.TerminateCallCount, "Second switch should have been ignored (count includes 1 from StopAsync)"); // 1 from first switch + 1 from StopAsync
+    }
+
+    // ── shutdown ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task StopAsync_TerminatesActiveProfile()
+    {
+        var config = MakeConfig("game1", MakeProfile("game1", ["game.exe"]));
+        var worker = MakeWorker(config, out _, out var pm, out _);
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, pm.TerminateCallCount);
+    }
+
+    [TestMethod]
+    public async Task StopAsync_StopsInputHandler()
+    {
+        var config = MakeConfig("game1", MakeProfile("game1", ["game.exe"]));
+        var worker = MakeWorker(config, out var ih, out _, out _);
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+        await cts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.IsTrue(ih.StopCalled);
     }
 
     // ── stubs / spies ─────────────────────────────────────────────────────────
@@ -210,6 +240,8 @@ public class WorkerTests
         /// <summary>Completes when the Worker calls StartAsync (i.e., the event subscription is set up).</summary>
         public Task WhenStarted => _startedTcs.Task;
 
+        public bool StopCalled { get; private set; }
+
         public void RaiseProfileSwitchRequested(string profileName) =>
             ProfileSwitchRequested?.Invoke(this, profileName);
 
@@ -220,7 +252,10 @@ public class WorkerTests
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
-            => Task.CompletedTask;
+        {
+            StopCalled = true;
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class SpyProcessManager : IProcessManager


### PR DESCRIPTION
## Summary

- Add `StopAsync` override to `Worker` that stops the input handler, terminates the active profile, and calls `base.StopAsync` — fixes processes being left running when the service stops
- Remove unreachable log statement that was after `Task.Delay(Timeout.Infinite)`
- Add `StopAsync_TerminatesActiveProfile` and `StopAsync_StopsInputHandler` tests; update existing test assertions to account for the new `TerminateActiveProfileAsync` call in `StopAsync`
- Add **Service Configuration** section to README documenting `sc.exe` recovery policy (FR-4.3) and user-account setup (FR-4.2)

## Test plan

- [x] `dotnet build` — no warnings or errors
- [x] `dotnet test` — all 70 relevant tests pass (1 pre-existing failure: `Initialize_WithJoystickConnected_ReturnsTrue` requires a physical joystick)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)