### PR TITLE
Fix WiX v5 Platform attribute error in release workflow

### DIFF
--- a/installer/ArcadeCabinetSwitcher.Installer/ArcadeCabinetSwitcher.Installer.wixproj
+++ b/installer/ArcadeCabinetSwitcher.Installer/ArcadeCabinetSwitcher.Installer.wixproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <InstallerVersion Condition="'$(InstallerVersion)' == ''">0.0.1</InstallerVersion>
+    <InstallerPlatform>x64</InstallerPlatform>
     <PublishDir Condition="'$(PublishDir)' == ''">..\..\publish\win-x64\</PublishDir>
     <DefineConstants>InstallerVersion=$(InstallerVersion);PublishDir=$(PublishDir)</DefineConstants>
   </PropertyGroup>

--- a/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
+++ b/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
@@ -6,8 +6,7 @@
            Language="1033"
            Version="$(InstallerVersion)"
            Manufacturer="Magnus Akselvoll"
-           UpgradeCode="{A7E8B5C6-D9F0-4321-8765-12AB34CD56EF}"
-           Platform="x64">
+           UpgradeCode="{A7E8B5C6-D9F0-4321-8765-12AB34CD56EF}">
 
     <!--
       MajorUpgrade scheduled afterInstallExecute so the new version installs first.


### PR DESCRIPTION
## Summary
- Removes `Platform="x64"` from `<Package>` in `Package.wxs` — WiX v5 no longer accepts this attribute
- Adds `<InstallerPlatform>x64</InstallerPlatform>` to the `<PropertyGroup>` in `ArcadeCabinetSwitcher.Installer.wixproj` — the correct WiX v5 way to set platform

## Test plan
- [ ] Re-run the release workflow and verify the "Build MSI" step succeeds without `WIX0004` error

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)