### PR TITLE
Fix MSI version format to strip pre-release labels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,11 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=$($env:GITHUB_REF_NAME -replace '^v','')" >> $env:GITHUB_OUTPUT
+        run: |
+          $version = $env:GITHUB_REF_NAME -replace '^v',''
+          $msiVersion = $version -replace '[-+].*$',''
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          echo "MSI_VERSION=$msiVersion" >> $env:GITHUB_OUTPUT
 
       - name: Publish win-x64
         run: >
@@ -54,7 +58,7 @@ jobs:
         run: >
           dotnet build installer/ArcadeCabinetSwitcher.Installer/ArcadeCabinetSwitcher.Installer.wixproj
           --configuration Release
-          -p:InstallerVersion=${{ steps.version.outputs.VERSION }}
+          -p:InstallerVersion=${{ steps.version.outputs.MSI_VERSION }}
           "-p:PublishDir=${{ github.workspace }}\publish\win-x64\"
 
       - name: Zip release asset


### PR DESCRIPTION
## Summary
- Extracts a separate `MSI_VERSION` from the tag by stripping pre-release labels (e.g. `0.0.1-alpha2` → `0.0.1`), since MSI package versions must be purely numeric
- Full `VERSION` (with pre-release label) is still used for file names and the release tag
- Pre-release MSIs (e.g. alpha builds) will share the same MSI version — upgrading between them requires a manual uninstall/reinstall, which is acceptable for pre-release builds

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)