### PR TITLE
Fix Serilog single-file publish crash

### DIFF
--- a/src/ArcadeCabinetSwitcher/Program.cs
+++ b/src/ArcadeCabinetSwitcher/Program.cs
@@ -3,6 +3,7 @@ using ArcadeCabinetSwitcher.Configuration;
 using ArcadeCabinetSwitcher.Input;
 using ArcadeCabinetSwitcher.ProcessManagement;
 using Serilog;
+using Serilog.Settings.Configuration;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddWindowsService(options =>
@@ -18,7 +19,10 @@ builder.Services.AddSingleton<IInputHandler, InputHandler>();
 builder.Services.AddHostedService<Worker>();
 
 builder.Services.AddSerilog((_, lc) =>
-    lc.ReadFrom.Configuration(builder.Configuration));
+    lc.ReadFrom.Configuration(builder.Configuration, new ConfigurationReaderOptions(
+        typeof(Serilog.ConsoleLoggerConfigurationExtensions).Assembly,
+        typeof(Serilog.FileLoggerConfigurationExtensions).Assembly,
+        typeof(Serilog.LoggerConfigurationEventLogExtensions).Assembly)));
 
 var host = builder.Build();
 host.Run();


### PR DESCRIPTION
## Summary

- Pass explicit assembly references via `ConfigurationReaderOptions` to `ReadFrom.Configuration()` in `Program.cs`
- Fixes crash on startup when installed via MSI (published as single-file executable), where Serilog's default assembly scanning cannot discover sink assemblies bundled inside the host executable

## Test plan

- [x] `dotnet build` passes
- [x] `dotnet test` passes (pre-existing joystick test failure unrelated to this change)
- [ ] On Windows: publish single-file and verify no crash on startup

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)