### PR TITLE
Fix ProgressText syntax for WiX v5

### DIFF
--- a/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
+++ b/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
@@ -32,13 +32,13 @@
     <UIRef Id="WixUI_Minimal" />
 
     <UI>
-      <ProgressText Action="InstallFiles">Installing application files...</ProgressText>
-      <ProgressText Action="InstallServices">Registering Windows service...</ProgressText>
-      <ProgressText Action="StartServices">Starting Windows service...</ProgressText>
-      <ProgressText Action="StopServices">Stopping Windows service...</ProgressText>
-      <ProgressText Action="DeleteServices">Removing Windows service...</ProgressText>
-      <ProgressText Action="RemoveFiles">Removing old files...</ProgressText>
-      <ProgressText Action="RemoveExistingProducts">Removing previous version...</ProgressText>
+      <ProgressText Action="InstallFiles" Message="Installing application files..." />
+      <ProgressText Action="InstallServices" Message="Registering Windows service..." />
+      <ProgressText Action="StartServices" Message="Starting Windows service..." />
+      <ProgressText Action="StopServices" Message="Stopping Windows service..." />
+      <ProgressText Action="DeleteServices" Message="Removing Windows service..." />
+      <ProgressText Action="RemoveFiles" Message="Removing old files..." />
+      <ProgressText Action="RemoveExistingProducts" Message="Removing previous version..." />
     </UI>
 
     <!--


### PR DESCRIPTION
## Summary

- Fixes WIX0400 build errors from PR #30: WiX v4/v5 no longer allows inner text on `ProgressText` elements
- Changed to attribute syntax: `Message="..."` instead of element inner text

## Root cause

WiX v3 used inner text for `ProgressText` content. In WiX v4/v5 this is illegal — the message must be passed via the `Message` attribute.

## Test plan

- [ ] MSI build succeeds: `dotnet build installer/ArcadeCabinetSwitcher.Installer/ArcadeCabinetSwitcher.Installer.wixproj`
- [ ] CI release workflow passes

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)