### PR TITLE
Fix WIX0094: use architecture-specific WixUI_Minimal variant

### DIFF
--- a/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
+++ b/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
@@ -29,7 +29,7 @@
     </Feature>
 
     <!-- Minimal UI: welcome dialog, progress bar with step messages, and finish dialog -->
-    <UIRef Id="WixUI_Minimal" />
+    <UIRef Id="WixUI_Minimal_$(sys.BUILDARCHSHORT)" />
 
     <UI>
       <ProgressText Action="InstallFiles" Message="Installing application files..." />


### PR DESCRIPTION
## Summary
- In WiX v5, `WixUI_Minimal` is internal (`Id="file WixUI_Minimal"`) and inaccessible via `<UIRef>`
- The public entry points are architecture-specific: `WixUI_Minimal_X86`, `WixUI_Minimal_X64`, `WixUI_Minimal_A64`
- Replace `WixUI_Minimal` with `WixUI_Minimal_$(sys.BUILDARCHSHORT)`, which resolves to `WixUI_Minimal_X64` for our x64 build

## Test plan
- [ ] CI release workflow builds the MSI without `WIX0094` errors
- [ ] `dotnet build` / `dotnet test` still pass (WiX project is not in `.slnx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)