### PR TITLE
Fix CI warnings: suppress ICE40/ICE61 and update Actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.wixproj', 'Directory.Packages.props') }}

--- a/installer/ArcadeCabinetSwitcher.Installer/ArcadeCabinetSwitcher.Installer.wixproj
+++ b/installer/ArcadeCabinetSwitcher.Installer/ArcadeCabinetSwitcher.Installer.wixproj
@@ -5,6 +5,10 @@
     <InstallerPlatform>x64</InstallerPlatform>
     <PublishDir Condition="'$(PublishDir)' == ''">..\..\publish\win-x64\</PublishDir>
     <DefineConstants>InstallerVersion=$(InstallerVersion);PublishDir=$(PublishDir)</DefineConstants>
+    <!-- Suppress expected ICE warnings:
+         ICE40: REINSTALLMODE in Property table (intentional: forces file replacement)
+         ICE61: AllowSameVersionUpgrades makes max version equal current (intentional: recovery from interrupted installs) -->
+    <SuppressIces>ICE40;ICE61</SuppressIces>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Suppress WIX1076 ICE40 and ICE61 warnings in `ArcadeCabinetSwitcher.Installer.wixproj` — these are expected consequences of the intentional resilience choices already documented in CLAUDE.md (`REINSTALLMODE=amus` and `AllowSameVersionUpgrades="yes"`)
- Update `actions/checkout`, `actions/setup-dotnet`, and `actions/cache` from `@v4` to `@v5` in both `ci.yml` and `release.yml` to eliminate Node.js 20 deprecation warnings (deprecated June 2026)

## Test plan

- [ ] Release workflow builds MSI without ICE40/ICE61 warnings
- [ ] CI workflow passes on ubuntu-latest
- [ ] No Node.js 20 deprecation warnings in either workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)