### PR TITLE
Fix license in installation set

### DIFF
--- a/installer/ArcadeCabinetSwitcher.Installer/License.rtf
+++ b/installer/ArcadeCabinetSwitcher.Installer/License.rtf
@@ -1,0 +1,13 @@
+{\rtf1\ansi\deff0
+{\fonttbl{\f0\froman\fcharset0 Times New Roman;}}
+\f0\fs20
+MIT License\par
+\par
+Copyright (c) 2026 magnusakselvoll\par
+\par
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
+\par
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
+\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
+}

--- a/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
+++ b/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
@@ -30,6 +30,7 @@
 
     <!-- Minimal UI: welcome dialog, progress bar with step messages, and finish dialog -->
     <UIRef Id="WixUI_Minimal_$(sys.BUILDARCHSHORT)" />
+    <WixVariable Id="WixUILicenseRtf" Value="License.rtf" />
 
     <UI>
       <ProgressText Action="InstallFiles" Message="Installing application files..." />


### PR DESCRIPTION
## Summary
- Add `License.rtf` with MIT License text converted to RTF format
- Wire it into `Package.wxs` via `WixUILicenseRtf` WiX variable so the `WixUI_Minimal` license dialog shows the MIT License instead of the Lorem Ipsum placeholder

## Test plan
- [ ] Build the installer on Windows and verify it compiles without errors
- [ ] Run the MSI and confirm the license dialog displays the MIT License text

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)