### PR TITLE
Switch from Windows Service to Task Scheduler for user-session launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ dotnet build
 # Run tests
 dotnet test
 
-# Run the service locally (gracefully degrades on non-Windows)
+# Run locally (console app — WinExe suppresses the window only on Windows)
 dotnet run --project src/ArcadeCabinetSwitcher
 
 # Build MSI installer (Windows only; publish win-x64 first)
@@ -62,7 +62,7 @@ arcade-cabinet-app-switcher/
 ├── Directory.Packages.props            # Central Package Management — all NuGet versions here
 ├── src/
 │   └── ArcadeCabinetSwitcher/
-│       ├── Program.cs                  # Host builder — AddWindowsService(), registers Worker and ConfigurationLoader
+│       ├── Program.cs                  # Host builder — Generic Host console app, registers Worker and ConfigurationLoader
 │       ├── Worker.cs                   # BackgroundService entry point — loads config on startup
 │       ├── profiles.json               # Default/example profile configuration (copied to output dir)
 │       ├── Configuration/              # Config POCOs, IConfigurationLoader, ConfigurationLoader, ConfigurationValidator
@@ -72,7 +72,7 @@ arcade-cabinet-app-switcher/
 │   ├── Directory.Build.props           # Empty — stops root Directory.Build.props from applying to WiX project
 │   └── ArcadeCabinetSwitcher.Installer/
 │       ├── ArcadeCabinetSwitcher.Installer.wixproj  # WiX v5 SDK-style project (NOT in .slnx — Windows-only)
-│       └── Package.wxs                 # MSI definition: service install, recovery policy, config preservation
+│       └── Package.wxs                 # MSI definition: Task Scheduler task, restart policy, config preservation
 └── tests/
     └── ArcadeCabinetSwitcher.Tests/    # MSTest test project
 ```
@@ -81,10 +81,10 @@ Key decisions:
 - **TFM**: `net10.0` (not `net10.0-windows`) — buildable on macOS; switch to `-windows` when Windows APIs are needed
 - **Central Package Management**: all NuGet package versions are pinned in `Directory.Packages.props`
 - **Shared MSBuild settings**: `Directory.Build.props` sets nullable, implicit usings, and warnings-as-errors for all projects
-- **Logging**: Serilog is used as the logging backend (infrastructure only — wired in `Program.cs` via `UseSerilog()`). All application code uses `Microsoft.Extensions.Logging.ILogger<T>`. Structured event IDs are defined in `src/ArcadeCabinetSwitcher/LogEvents.cs`. Console and Windows Event Log sinks are configured in `appsettings.json` under the `Serilog` key. The File sink is configured programmatically in `Program.cs` to write to `%ProgramData%\ArcadeCabinetSwitcher\logs\arcade-cabinet-switcher.log` (absolute path, so it works correctly when the service runs as SYSTEM). Serilog auto-creates the log directory.
+- **Logging**: Serilog is used as the logging backend (infrastructure only — wired in `Program.cs` via `UseSerilog()`). All application code uses `Microsoft.Extensions.Logging.ILogger<T>`. Structured event IDs are defined in `src/ArcadeCabinetSwitcher/LogEvents.cs`. Console and Windows Event Log sinks are configured in `appsettings.json` under the `Serilog` key. The File sink is configured programmatically in `Program.cs` to write to `%ProgramData%\ArcadeCabinetSwitcher\logs\arcade-cabinet-switcher.log` (absolute path, consistent across all run contexts). Serilog auto-creates the log directory.
 - **Configuration loading**: Profile configuration is loaded from `profiles.json` (separate from `appsettings.json`) using `System.Text.Json`. `ConfigurationLoader` takes an optional `configFilePath` constructor parameter (defaults to `AppContext.BaseDirectory/profiles.json`) to enable testing without mocking. `ConfigurationValidator` is an `internal` static class with `InternalsVisibleTo` for the test project.
 - **MSTest assertions**: MSTest 4.x removed `Assert.ThrowsException<T>` and `[ExpectedException]`; use `Assert.ThrowsExactly<T>` instead.
-- **WiX installer**: WiX v5 SDK-style project (`Sdk="WixToolset.Sdk/5.0.2"`). Not added to the `.slnx` — WiX only builds on Windows, whereas CI (`dotnet build`/`dotnet test`) runs on ubuntu-latest. Built explicitly in the release workflow only. `installer/Directory.Build.props` is intentionally empty to prevent the root `Directory.Build.props` (C# settings) from being applied to the WiX project. Resilience strategy: `AllowSameVersionUpgrades="yes"` makes re-running the same MSI trigger a full upgrade cycle instead of maintenance mode; `REINSTALLMODE=amus` forces file replacement regardless of version stamps (NeverOverwrite components are unaffected). UI provided by `WixToolset.UI.wixext` (`WixUI_Minimal`): shows progress with step messages and displays config/log file paths in the finish dialog.
+- **WiX installer**: WiX v5 SDK-style project (`Sdk="WixToolset.Sdk/5.0.2"`). Not added to the `.slnx` — WiX only builds on Windows, whereas CI (`dotnet build`/`dotnet test`) runs on ubuntu-latest. Built explicitly in the release workflow only. `installer/Directory.Build.props` is intentionally empty to prevent the root `Directory.Build.props` (C# settings) from being applied to the WiX project. Resilience strategy: `AllowSameVersionUpgrades="yes"` makes re-running the same MSI trigger a full upgrade cycle instead of maintenance mode; `REINSTALLMODE=amus` forces file replacement regardless of version stamps (NeverOverwrite components are unaffected). UI provided by `WixToolset.UI.wixext` (`WixUI_Minimal`): shows progress with step messages and displays config/log file paths in the finish dialog. Task Scheduler management uses `WixQuietExec` from `WixToolset.Util.wixext` (`BinaryRef="Wix4UtilCA_X64"`): PowerShell `Register-ScheduledTask` creates the logon-trigger task with restart-on-failure settings; `schtasks /Delete` removes it on uninstall; `taskkill` stops any running instance before upgrade/uninstall.
 - **SDL2 / native library**: The release workflow publishes with `IncludeNativeLibrariesForSelfExtract=false` so SDL2.dll is placed alongside the exe on disk (Silk.NET finds it via P/Invoke). Setting this to `true` embeds SDL2.dll inside the single-file exe, which breaks runtime loading. SDL2.dll is explicitly listed as a `Sdl2Native` component in `Package.wxs`, so it is included in the MSI alongside the executable.
 - **Button discovery**: When 2+ joystick buttons are held simultaneously for 10+ seconds, `InputHandler` logs at Information level with `profiles.json`-ready syntax (`ButtonDiscoveryLogged` event 5009). This is always-on (not gated by `InputDebugMode`) to help arcade operators identify button mappings without trial and error.
 
@@ -92,7 +92,7 @@ Key decisions:
 
 - **Language**: C#
 - **Runtime**: .NET 10
-- **Application type**: Windows Service (Generic Host with `UseWindowsService()`)
+- **Application type**: Generic Host console app (`WinExe` output type suppresses the window; launched at logon via Task Scheduler)
 
 ## Reference
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
 
   <ItemGroup Label="Service">
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
     <PackageVersion Include="Silk.NET.SDL" Version="2.23.0" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arcade Cabinet App Switcher
 
-A Windows Service that acts as an application launcher and switcher for a Windows-based arcade cabinet. It starts automatically on boot, launches a default profile, and lets users switch between profiles using joystick button combinations — no keyboard or mouse required.
+A startup application that acts as an application launcher and switcher for a Windows-based arcade cabinet. It starts automatically at user logon via Task Scheduler, launches a default profile, and lets users switch between profiles using joystick button combinations — no keyboard or mouse required.
 
 > **Status:** Early development. The core project scaffold is in place; full functionality is under active development. See [SPEC.md](SPEC.md) for the full functional specification.
 
@@ -11,7 +11,7 @@ A Windows Service that acts as an application launcher and switcher for a Window
 - **Joystick-driven switching** — Switch profiles by holding a configurable button combo for a set duration (e.g., 10 seconds)
 - **Clean process termination** — Tracks child/sub-processes to ensure everything is properly closed when switching profiles
 - **Special profiles** — Built-in support for reboot and shutdown profiles
-- **Reliable service** — Windows Service with recovery policy: restart on first/second failure, reboot on third
+- **Reliable** — Automatic restart on failure via Task Scheduler; starts automatically at user logon
 - **JSON configuration** — All profiles and combos are defined in a simple JSON settings file
 - **Windows Installer (MSI)** — Packaged for easy installation and upgrade
 - **Logging** — Service events, profile switches, and errors written to Windows Event Log and/or file
@@ -33,7 +33,7 @@ dotnet build
 # Run tests
 dotnet test
 
-# Run locally (console mode — UseWindowsService() degrades gracefully on non-Windows)
+# Run locally
 dotnet run --project src/ArcadeCabinetSwitcher
 ```
 
@@ -68,31 +68,11 @@ See [SPEC.md](SPEC.md) for the full configuration format and validation rules.
 Download the `.msi` from the [Releases](https://github.com/magnusakselvoll/arcade-cabinet-app-switcher/releases) page and run it. The installer:
 
 - Copies files to `C:\Program Files\ArcadeCabinetSwitcher\`
-- Registers the `ArcadeCabinetSwitcher` Windows service (auto-start, LocalSystem account)
-- Configures the service recovery policy automatically (see below)
+- Registers the `ArcadeCabinetSwitcher` Task Scheduler task (logon trigger, runs as the logged-in user)
+- Configures the restart policy automatically: restarts up to 3 times on failure (5-second delay)
 - Preserves existing `appsettings.json` and `profiles.json` when upgrading
 
-After installation, the service starts immediately. Edit `profiles.json` in the install directory to configure your profiles, then restart the service.
-
-## Service Configuration (Windows)
-
-### User Account (FR-4.2)
-
-By default, Windows services run as `LocalSystem`. To run as a specific user (e.g., the auto-login arcade account), run as Administrator:
-
-```cmd
-sc.exe config ArcadeCabinetSwitcher obj= "DOMAIN\username" password= "password"
-```
-
-### Recovery Policy (FR-4.3)
-
-The MSI installer configures the recovery policy automatically: restart on the first and second failure (5-second delay), reboot on the third failure within a 24-hour window.
-
-For manual installs, configure recovery with (run as Administrator):
-
-```cmd
-sc.exe failure ArcadeCabinetSwitcher reset= 86400 actions= restart/5000/restart/5000/reboot/5000
-```
+After installation, the application starts immediately. Edit `profiles.json` in the install directory to configure your profiles, then restart the task (`schtasks /End /TN ArcadeCabinetSwitcher` and `schtasks /Run /TN ArcadeCabinetSwitcher`).
 
 ## Logging
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -4,7 +4,7 @@ This document describes how the arcade cabinet app switcher should work. It serv
 
 ## Overview
 
-The Arcade Cabinet App Switcher is a Windows service that acts as an application launcher and switcher for a Windows-based arcade cabinet. When the machine powers on, Windows auto-logs in and the service starts automatically, launching the default profile. Users can switch between profiles using joystick button combinations on the arcade controls, without needing a keyboard or mouse.
+The Arcade Cabinet App Switcher is a startup application managed by Task Scheduler that acts as an application launcher and switcher for a Windows-based arcade cabinet. When the machine powers on, Windows auto-logs in and the application starts automatically, launching the default profile. Users can switch between profiles using joystick button combinations on the arcade controls, without needing a keyboard or mouse.
 
 ## Terminology
 
@@ -15,17 +15,17 @@ The Arcade Cabinet App Switcher is a Windows service that acts as an application
 | **Switch combo** | A configurable combination of joystick buttons that, when held for a configured duration, triggers a switch to a specific profile |
 | **Hold duration** | The number of seconds a switch combo must be held before the switch is triggered |
 | **Active profile** | The profile whose processes are currently running |
-| **Service** | The Windows Service that hosts the app switcher logic and runs in user context |
+| **Application** | The startup application managed by Task Scheduler that hosts the app switcher logic and runs in the logged-in user's session |
 
 ## Use Cases
 
 ### UC-1: System Startup
 
 1. The Windows machine powers on and automatically logs in to a configured user account
-2. The Windows Service starts in that user's context
-3. The service loads the configuration file
-4. The service launches the default profile's commands
-5. The service begins monitoring for joystick input
+2. Task Scheduler starts the application in the logged-in user's context
+3. The application loads the configuration file
+4. The application launches the default profile's commands
+5. The application begins monitoring for joystick input
 
 ### UC-2: Profile Switching
 
@@ -55,12 +55,11 @@ The Arcade Cabinet App Switcher is a Windows service that acts as an application
 4. Any processes that have not exited are forcefully terminated
 5. The service confirms all processes are stopped before proceeding
 
-### UC-6: Service Recovery
+### UC-6: Application Recovery
 
-1. The service fails or crashes
-2. Windows Service recovery policy restarts the service automatically (first and second failures)
-3. On the third failure, the recovery policy reboots the machine
-4. After each restart, the service resumes normal operation including launching the default profile
+1. The application fails or crashes
+2. Task Scheduler restart policy restarts the application automatically (up to 3 times, 5-second delay)
+3. After each restart, the application resumes normal operation including launching the default profile
 
 ## Functional Requirements
 
@@ -91,20 +90,20 @@ The Arcade Cabinet App Switcher is a Windows service that acts as an application
 - **FR-3.4** Termination is attempted gracefully first (e.g., WM_CLOSE or equivalent); processes not exiting within a short timeout are forcefully killed
 - **FR-3.5** The service waits for all processes to exit before launching the next profile
 
-### FR-4: Windows Service
+### FR-4: Startup and Recovery
 
-- **FR-4.1** The app switcher runs as a Windows Service
-- **FR-4.2** The service runs in the logged-in user's context (not as SYSTEM or a dedicated service account) so that launched processes have access to the user's desktop session and environment
-- **FR-4.3** The service is configured with a recovery policy:
-  - First failure: restart the service
-  - Second failure: restart the service
-  - Third failure: reboot the machine
-- **FR-4.4** The service starts automatically when Windows starts (after auto-login)
+- **FR-4.1** The app switcher runs as a startup application managed by Task Scheduler
+- **FR-4.2** The application runs in the logged-in user's interactive session so that launched processes have access to the user's desktop and environment
+- **FR-4.3** The application is configured with a restart policy via Task Scheduler:
+  - First failure: restart the application (5-second delay)
+  - Second and third failure: restart the application (5-second delay)
+  - Note: Task Scheduler does not support reboot-on-failure; automatic machine reboot on repeated failure is not supported
+- **FR-4.4** The application starts automatically at user logon via Task Scheduler
 
 ### FR-5: Installation
 
 - **FR-5.1** The service is distributed as a Windows Installer package (MSI)
-- **FR-5.2** The installer registers the service with Windows and configures the recovery policy
+- **FR-5.2** The installer registers a scheduled task with Windows and configures the restart policy
 - **FR-5.3** The installer places the configuration file at the expected location with default/example content if no configuration exists
 - **FR-5.4** The installer supports upgrading an existing installation without requiring manual uninstallation
 - **FR-5.5** The installer recovers gracefully from interrupted installations — re-running the same version overwrites the previous installation regardless of its state
@@ -179,7 +178,7 @@ The configuration is stored as a JSON file. The following is an example showing 
 
 ## Non-Functional Requirements
 
-- **Reliability**: The service must be stable under continuous operation. The Windows Service recovery policy acts as a safety net, but crashes should be minimised through robust error handling.
+- **Reliability**: The application must be stable under continuous operation. The Task Scheduler restart policy acts as a safety net, but crashes should be minimised through robust error handling.
 - **Platform**: Windows only. No cross-platform support is required or planned.
 - **User context**: All launched applications must run in the interactive user session, not as background or system-level processes.
 - **Low resource usage**: The service should have minimal CPU and memory overhead when idle (waiting for input or running a profile).

--- a/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
+++ b/installer/ArcadeCabinetSwitcher.Installer/Package.wxs
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
   <Package Name="Arcade Cabinet App Switcher"
            Language="1033"
@@ -34,10 +33,10 @@
 
     <UI>
       <ProgressText Action="InstallFiles" Message="Installing application files..." />
-      <ProgressText Action="InstallServices" Message="Registering Windows service..." />
-      <ProgressText Action="StartServices" Message="Starting Windows service..." />
-      <ProgressText Action="StopServices" Message="Stopping Windows service..." />
-      <ProgressText Action="DeleteServices" Message="Removing Windows service..." />
+      <ProgressText Action="StopApplication" Message="Stopping running instance..." />
+      <ProgressText Action="CreateScheduledTask" Message="Registering scheduled task..." />
+      <ProgressText Action="StartScheduledTask" Message="Starting application..." />
+      <ProgressText Action="DeleteScheduledTask" Message="Removing scheduled task..." />
       <ProgressText Action="RemoveFiles" Message="Removing old files..." />
       <ProgressText Action="RemoveExistingProducts" Message="Removing previous version..." />
     </UI>
@@ -51,6 +50,76 @@
                  Sequence="ui"
                  Value="Configuration files:&#xA;  [INSTALLFOLDER]profiles.json&#xA;  [INSTALLFOLDER]appsettings.json&#xA;Log files:&#xA;  [CommonAppDataFolder]ArcadeCabinetSwitcher\logs\" />
 
+    <!--
+      Custom actions for Task Scheduler management.
+      Each SetProperty sets the CustomActionData (command line) for its paired deferred CA.
+      WixQuietExec runs the command from CustomActionData in an elevated, non-impersonated context.
+    -->
+
+    <!-- Stop any running instance before upgrade or uninstall (ignore failure — may not be running) -->
+    <SetProperty Id="StopApplication"
+                 Value="taskkill.exe /IM ArcadeCabinetSwitcher.exe /F"
+                 Before="StopApplication"
+                 Sequence="execute" />
+    <CustomAction Id="StopApplication"
+                  BinaryRef="Wix4UtilCA_X64"
+                  DllEntry="WixQuietExec"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="ignore" />
+
+    <!--
+      Create scheduled task: logon trigger, runs as interactive user (S-1-5-4), restarts on failure.
+      [SystemFolder] expands to C:\Windows\System32\ in a 64-bit installer.
+      [INSTALLFOLDER] expands to the installation directory (includes trailing backslash).
+      PowerShell settings: RestartCount=3, RestartInterval=5s, always run on battery, hidden from UI.
+    -->
+    <SetProperty Id="CreateScheduledTask"
+                 Value="&quot;[SystemFolder]WindowsPowerShell\v1.0\powershell.exe&quot; -NonInteractive -ExecutionPolicy Bypass -Command &quot;$a=New-ScheduledTaskAction -Execute '[INSTALLFOLDER]ArcadeCabinetSwitcher.exe';$t=New-ScheduledTaskTrigger -AtLogOn;$s=New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval (New-TimeSpan -Seconds 5) -DisallowStartIfOnBatteries:$false -Hidden;$p=New-ScheduledTaskPrincipal -GroupId S-1-5-4 -RunLevel Limited;Register-ScheduledTask ArcadeCabinetSwitcher -Action $a -Trigger $t -Settings $s -Principal $p -Force&quot;"
+                 Before="CreateScheduledTask"
+                 Sequence="execute" />
+    <CustomAction Id="CreateScheduledTask"
+                  BinaryRef="Wix4UtilCA_X64"
+                  DllEntry="WixQuietExec"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check" />
+
+    <!-- Start the task immediately after installation (ignore failure — may require user session) -->
+    <SetProperty Id="StartScheduledTask"
+                 Value="schtasks.exe /Run /TN &quot;ArcadeCabinetSwitcher&quot;"
+                 Before="StartScheduledTask"
+                 Sequence="execute" />
+    <CustomAction Id="StartScheduledTask"
+                  BinaryRef="Wix4UtilCA_X64"
+                  DllEntry="WixQuietExec"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="ignore" />
+
+    <!-- Delete scheduled task on uninstall (ignore failure — task may not exist) -->
+    <SetProperty Id="DeleteScheduledTask"
+                 Value="schtasks.exe /Delete /TN &quot;ArcadeCabinetSwitcher&quot; /F"
+                 Before="DeleteScheduledTask"
+                 Sequence="execute" />
+    <CustomAction Id="DeleteScheduledTask"
+                  BinaryRef="Wix4UtilCA_X64"
+                  DllEntry="WixQuietExec"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="ignore" />
+
+    <InstallExecuteSequence>
+      <!-- Stop running instance before installing new files (upgrade) or removing (uninstall) -->
+      <Custom Action="StopApplication" Before="InstallFiles">REMOVE="ALL" OR WIX_UPGRADE_DETECTED</Custom>
+      <!-- Create task after files are in place, on install or upgrade -->
+      <Custom Action="CreateScheduledTask" After="InstallFiles">NOT REMOVE</Custom>
+      <!-- Start the task immediately; ignore failure if no interactive session is available -->
+      <Custom Action="StartScheduledTask" After="CreateScheduledTask">NOT REMOVE</Custom>
+      <!-- Delete task before removing files on full uninstall -->
+      <Custom Action="DeleteScheduledTask" Before="RemoveFiles">REMOVE="ALL"</Custom>
+    </InstallExecuteSequence>
+
   </Package>
 
   <Fragment>
@@ -62,32 +131,9 @@
   <Fragment>
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
 
-      <!--
-        Main executable with service registration and recovery policy (FR-4.3).
-        Recovery: restart after 1st and 2nd failure, reboot after 3rd, reset window = 1 day.
-      -->
+      <!-- Main executable -->
       <Component Id="MainExecutable">
         <File Source="$(PublishDir)ArcadeCabinetSwitcher.exe" KeyPath="yes" />
-        <ServiceInstall Id="ServiceInstall"
-                        Name="ArcadeCabinetSwitcher"
-                        DisplayName="Arcade Cabinet App Switcher"
-                        Description="Launches and switches profiles on an arcade cabinet."
-                        Start="auto"
-                        Type="ownProcess"
-                        Account="LocalSystem"
-                        ErrorControl="normal" />
-        <ServiceControl Id="ServiceControl"
-                        Name="ArcadeCabinetSwitcher"
-                        Start="install"
-                        Stop="both"
-                        Remove="uninstall"
-                        Wait="yes" />
-        <util:ServiceConfig ServiceName="ArcadeCabinetSwitcher"
-                            FirstFailureActionType="restart"
-                            SecondFailureActionType="restart"
-                            ThirdFailureActionType="reboot"
-                            RestartServiceDelayInSeconds="5"
-                            ResetPeriodInDays="1" />
       </Component>
 
       <!-- NeverOverwrite preserves user edits to appsettings.json across upgrades (FR-5.3) -->

--- a/src/ArcadeCabinetSwitcher/ArcadeCabinetSwitcher.csproj
+++ b/src/ArcadeCabinetSwitcher/ArcadeCabinetSwitcher.csproj
@@ -2,13 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="Serilog.Settings.Configuration" />
     <PackageReference Include="Serilog.Sinks.Console" />

--- a/src/ArcadeCabinetSwitcher/Program.cs
+++ b/src/ArcadeCabinetSwitcher/Program.cs
@@ -11,10 +11,6 @@ var programData = Environment.GetEnvironmentVariable("ProgramData")
 var logPath = Path.Combine(programData, "ArcadeCabinetSwitcher", "logs", "arcade-cabinet-switcher.log");
 
 var builder = Host.CreateApplicationBuilder(args);
-builder.Services.AddWindowsService(options =>
-{
-    options.ServiceName = "ArcadeCabinetSwitcher";
-});
 builder.Services.AddSingleton<IConfigurationLoader, ConfigurationLoader>();
 builder.Services.AddSingleton<IProcessLauncher, SystemProcessLauncher>();
 builder.Services.AddSingleton<IProcessManager, ProcessManager>();


### PR DESCRIPTION
## Summary

- Removes `AddWindowsService()` — app is now a plain Generic Host console app (`WinExe` output type suppresses the console window)
- Removes `Microsoft.Extensions.Hosting.WindowsServices` NuGet dependency
- Replaces `ServiceInstall`/`ServiceControl`/`ServiceConfig` in `Package.wxs` with Task Scheduler custom actions using `WixQuietExec`: PowerShell `Register-ScheduledTask` (logon trigger, interactive user principal `S-1-5-4`, restart-on-failure 3×/5s), `schtasks /Run` on install, `schtasks /Delete` on uninstall, `taskkill` before upgrade/uninstall
- Updates SPEC.md (FR-4, FR-5.2, UC-1, UC-6), CLAUDE.md, and README.md to reflect the Task Scheduler approach

## Why

Running as a Windows Service under `LocalSystem` (Session 0) meant launched apps were invisible on the user's desktop and SDL2 couldn't enumerate joystick controllers. Task Scheduler with a logon trigger and interactive user principal naturally runs in the user's session, fixing both issues.

## Test plan

- [ ] `dotnet build` passes (verified locally)
- [ ] `dotnet test` passes (72/73 — 1 pre-existing failure requires physical joystick)
- [ ] On Windows: install MSI, verify scheduled task `ArcadeCabinetSwitcher` is created in Task Scheduler
- [ ] On Windows: verify app starts at logon and launched games appear on the desktop
- [ ] On Windows: uninstall MSI, verify task is deleted
- [ ] On Windows: upgrade from previous version (service-based), verify service is removed and task is created

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)