### PR TITLE
Log crashes to file and flush Serilog on shutdown

### DIFF
--- a/src/ArcadeCabinetSwitcher/Input/InputHandler.cs
+++ b/src/ArcadeCabinetSwitcher/Input/InputHandler.cs
@@ -61,6 +61,10 @@ internal sealed class InputHandler : IInputHandler
             {
                 // Shutdown timeout
             }
+            catch (Exception ex)
+            {
+                _logger.LogError(LogEvents.UnexpectedException, ex, "Input polling task faulted");
+            }
         }
 
         _linkedCts?.Dispose();

--- a/src/ArcadeCabinetSwitcher/Input/SdlJoystickReader.cs
+++ b/src/ArcadeCabinetSwitcher/Input/SdlJoystickReader.cs
@@ -18,6 +18,53 @@ internal sealed class SdlJoystickReader : IJoystickReader
         try
         {
             _sdl = Sdl.GetApi();
+
+            // Headless hints — must be set before SDL_Init.
+            // Windows: spin up a dedicated joystick thread so no Win32 message pump is needed.
+            _sdl.SetHint(Sdl.HintJoystickThread, "1");
+            // Allow joystick events when the process has no foreground window.
+            _sdl.SetHint(Sdl.HintJoystickAllowBackgroundEvents, "1");
+            // macOS: disable the GameController (MFi) driver, which requires AppKit setup on the
+            // main thread. Arcade cabinet USB encoder boards are plain HID devices handled by
+            // SDL2's HIDAPI backend, which works headlessly on all platforms without SDL_INIT_VIDEO.
+            _sdl.SetHint("SDL_JOYSTICK_MFI", "0");
+
+            if (_sdl.Init(Sdl.InitJoystick) < 0)
+            {
+                _logger.LogWarning(LogEvents.JoystickNotFound,
+                    "SDL init failed: {Error}", _sdl.GetErrorS());
+                _sdl.Dispose();
+                _sdl = null;
+                return false;
+            }
+
+            int count = _sdl.NumJoysticks();
+            for (int i = 0; i < count; i++)
+            {
+                Joystick* joy = _sdl.JoystickOpen(i);
+                if (joy == null)
+                {
+                    _logger.LogWarning(LogEvents.InputError,
+                        "Failed to open joystick {Index}: {Error}", i, _sdl.GetErrorS());
+                    continue;
+                }
+
+                _joystickHandles.Add((nint)joy);
+                _logger.LogInformation(LogEvents.JoystickAcquired,
+                    "Acquired joystick {Index}: {Name} ({ButtonCount} buttons)",
+                    i, _sdl.JoystickNameS(joy), _sdl.JoystickNumButtons(joy));
+            }
+
+            if (_joystickHandles.Count == 0)
+            {
+                _logger.LogWarning(LogEvents.JoystickNotFound, "No joystick devices found");
+                _sdl.Quit();
+                _sdl.Dispose();
+                _sdl = null;
+                return false;
+            }
+
+            return true;
         }
         catch (Exception ex) when (ex is FileNotFoundException or DllNotFoundException)
         {
@@ -25,53 +72,6 @@ internal sealed class SdlJoystickReader : IJoystickReader
                 "SDL2 native library not found. Ensure SDL2.dll is present alongside the executable. Input monitoring disabled.");
             return false;
         }
-
-        // Headless hints — must be set before SDL_Init.
-        // Windows: spin up a dedicated joystick thread so no Win32 message pump is needed.
-        _sdl.SetHint(Sdl.HintJoystickThread, "1");
-        // Allow joystick events when the process has no foreground window.
-        _sdl.SetHint(Sdl.HintJoystickAllowBackgroundEvents, "1");
-        // macOS: disable the GameController (MFi) driver, which requires AppKit setup on the
-        // main thread. Arcade cabinet USB encoder boards are plain HID devices handled by
-        // SDL2's HIDAPI backend, which works headlessly on all platforms without SDL_INIT_VIDEO.
-        _sdl.SetHint("SDL_JOYSTICK_MFI", "0");
-
-        if (_sdl.Init(Sdl.InitJoystick) < 0)
-        {
-            _logger.LogWarning(LogEvents.JoystickNotFound,
-                "SDL init failed: {Error}", _sdl.GetErrorS());
-            _sdl.Dispose();
-            _sdl = null;
-            return false;
-        }
-
-        int count = _sdl.NumJoysticks();
-        for (int i = 0; i < count; i++)
-        {
-            Joystick* joy = _sdl.JoystickOpen(i);
-            if (joy == null)
-            {
-                _logger.LogWarning(LogEvents.InputError,
-                    "Failed to open joystick {Index}: {Error}", i, _sdl.GetErrorS());
-                continue;
-            }
-
-            _joystickHandles.Add((nint)joy);
-            _logger.LogInformation(LogEvents.JoystickAcquired,
-                "Acquired joystick {Index}: {Name} ({ButtonCount} buttons)",
-                i, _sdl.JoystickNameS(joy), _sdl.JoystickNumButtons(joy));
-        }
-
-        if (_joystickHandles.Count == 0)
-        {
-            _logger.LogWarning(LogEvents.JoystickNotFound, "No joystick devices found");
-            _sdl.Quit();
-            _sdl.Dispose();
-            _sdl = null;
-            return false;
-        }
-
-        return true;
     }
 
     public unsafe IReadOnlySet<string> GetPressedButtons()

--- a/src/ArcadeCabinetSwitcher/LogEvents.cs
+++ b/src/ArcadeCabinetSwitcher/LogEvents.cs
@@ -17,6 +17,7 @@ public static class LogEvents
     // Service lifecycle
     public static readonly EventId ServiceStarting = new(1000, nameof(ServiceStarting));
     public static readonly EventId ServiceStopping = new(1001, nameof(ServiceStopping));
+    public static readonly EventId ApplicationTerminated = new(1002, nameof(ApplicationTerminated));
 
     // Configuration
     public static readonly EventId ConfigurationLoaded = new(2000, nameof(ConfigurationLoaded));

--- a/src/ArcadeCabinetSwitcher/Program.cs
+++ b/src/ArcadeCabinetSwitcher/Program.cs
@@ -31,4 +31,16 @@ builder.Services.AddSerilog((_, lc) =>
           restrictedToMinimumLevel: LogEventLevel.Verbose));
 
 var host = builder.Build();
-host.Run();
+
+try
+{
+    host.Run();
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Application terminated unexpectedly");
+}
+finally
+{
+    Log.CloseAndFlush();
+}


### PR DESCRIPTION
## Summary

- Wrap `host.Run()` in try/catch/finally so unhandled exceptions are logged via `Log.Fatal` to all sinks (including the file) before the process exits
- Call `Log.CloseAndFlush()` in the finally block to flush buffered writes on both normal and abnormal shutdown
- Add `ApplicationTerminated` (event 1002) to `LogEvents` for the fatal crash entry
- Widen `SdlJoystickReader.Initialize()` try/catch to cover the full method body so `DllNotFoundException` from `SetHint`/`Init` is caught gracefully
- Catch general exceptions in `InputHandler.StopAsync` when awaiting the polling task to prevent a faulted task propagating as an unhandled exception during shutdown

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)