### PR TITLE
Add overlay notification and system tray icon

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,12 @@
     <PackageVersion Include="Silk.NET.SDL" Version="2.23.0" />
   </ItemGroup>
 
+  <ItemGroup Label="UI">
+    <PackageVersion Include="Avalonia" Version="11.2.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.2.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.1" />
+  </ItemGroup>
+
   <ItemGroup Label="Logging">
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />

--- a/src/ArcadeCabinetSwitcher/ArcadeCabinetSwitcher.csproj
+++ b/src/ArcadeCabinetSwitcher/ArcadeCabinetSwitcher.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="Serilog.Settings.Configuration" />

--- a/src/ArcadeCabinetSwitcher/LogEvents.cs
+++ b/src/ArcadeCabinetSwitcher/LogEvents.cs
@@ -56,6 +56,11 @@ public static class LogEvents
     public static readonly EventId ButtonDiscoveryLogged = new(5009, nameof(ButtonDiscoveryLogged));
     public static readonly EventId SdlLibraryNotFound = new(5010, nameof(SdlLibraryNotFound));
 
+    // UI (overlay / tray)
+    public static readonly EventId OverlayShown = new(6000, nameof(OverlayShown));
+    public static readonly EventId TrayIconInitialized = new(6001, nameof(TrayIconInitialized));
+    public static readonly EventId ExitRequestedFromTray = new(6002, nameof(ExitRequestedFromTray));
+
     // Errors
     public static readonly EventId UnexpectedException = new(9000, nameof(UnexpectedException));
 }

--- a/src/ArcadeCabinetSwitcher/Program.cs
+++ b/src/ArcadeCabinetSwitcher/Program.cs
@@ -2,6 +2,11 @@ using ArcadeCabinetSwitcher;
 using ArcadeCabinetSwitcher.Configuration;
 using ArcadeCabinetSwitcher.Input;
 using ArcadeCabinetSwitcher.ProcessManagement;
+using ArcadeCabinetSwitcher.UI;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
 using Serilog;
 using Serilog.Events;
 using Serilog.Settings.Configuration;
@@ -11,6 +16,7 @@ var programData = Environment.GetEnvironmentVariable("ProgramData")
 var logPath = Path.Combine(programData, "ArcadeCabinetSwitcher", "logs", "arcade-cabinet-switcher.log");
 
 var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddSingleton<IOverlayService, AvaloniaOverlayService>();
 builder.Services.AddSingleton<IConfigurationLoader, ConfigurationLoader>();
 builder.Services.AddSingleton<IProcessLauncher, SystemProcessLauncher>();
 builder.Services.AddSingleton<IProcessManager, ProcessManager>();
@@ -32,9 +38,32 @@ builder.Services.AddSerilog((_, lc) =>
 
 var host = builder.Build();
 
+var overlayService = (AvaloniaOverlayService)host.Services.GetRequiredService<IOverlayService>();
+var appLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+// Exit via tray → stop host
+overlayService.ExitRequested += (_, _) =>
+{
+    Log.Information(LogEvents.ExitRequestedFromTray.Name!, "Exit requested from tray icon");
+    appLifetime.StopApplication();
+};
+
+// Start host (starts Worker as background service)
+await host.StartAsync();
+
+// Host stopping → shut down Avalonia
+appLifetime.ApplicationStopping.Register(() =>
+    Dispatcher.UIThread.Post(() =>
+        (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.Shutdown()));
+
+// Pass overlay service to App before running Avalonia
+App.OverlayService = overlayService;
+
 try
 {
-    host.Run();
+    AppBuilder.Configure<App>()
+        .UsePlatformDetect()
+        .StartWithClassicDesktopLifetime(args, ShutdownMode.OnExplicitShutdown);
 }
 catch (Exception ex)
 {
@@ -42,5 +71,6 @@ catch (Exception ex)
 }
 finally
 {
+    await host.StopAsync();
     Log.CloseAndFlush();
 }

--- a/src/ArcadeCabinetSwitcher/UI/App.axaml
+++ b/src/ArcadeCabinetSwitcher/UI/App.axaml
@@ -1,0 +1,7 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ArcadeCabinetSwitcher.UI.App">
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/src/ArcadeCabinetSwitcher/UI/App.axaml.cs
+++ b/src/ArcadeCabinetSwitcher/UI/App.axaml.cs
@@ -1,0 +1,33 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace ArcadeCabinetSwitcher.UI;
+
+public partial class App : Application
+{
+    internal static AvaloniaOverlayService? OverlayService { get; set; }
+
+    private TrayIconManager? _trayIconManager;
+
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            desktop.Exit += (_, _) => _trayIconManager?.Dispose();
+
+            if (OverlayService is not null)
+            {
+                var overlayWindow = new OverlayWindow();
+                _trayIconManager = new TrayIconManager(this);
+                OverlayService.Initialize(overlayWindow, _trayIconManager);
+            }
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/ArcadeCabinetSwitcher/UI/AvaloniaOverlayService.cs
+++ b/src/ArcadeCabinetSwitcher/UI/AvaloniaOverlayService.cs
@@ -1,0 +1,63 @@
+using Avalonia.Threading;
+
+namespace ArcadeCabinetSwitcher.UI;
+
+public class AvaloniaOverlayService : IOverlayService
+{
+    private readonly object _lock = new();
+    private readonly Queue<Action> _pending = new();
+    private bool _uiReady;
+
+    private OverlayWindow? _overlayWindow;
+    private TrayIconManager? _trayIconManager;
+
+    public event EventHandler<string>? ProfileSwitchRequested;
+    public event EventHandler? ExitRequested;
+
+    internal void Initialize(OverlayWindow overlayWindow, TrayIconManager trayIconManager)
+    {
+        // Called on UI thread from App.OnFrameworkInitializationCompleted
+        _overlayWindow = overlayWindow;
+        _trayIconManager = trayIconManager;
+
+        trayIconManager.ProfileSwitchRequested += (_, name) =>
+            ProfileSwitchRequested?.Invoke(this, name);
+        trayIconManager.ExitRequested += (_, _) =>
+            ExitRequested?.Invoke(this, EventArgs.Empty);
+
+        List<Action> drained;
+        lock (_lock)
+        {
+            _uiReady = true;
+            drained = [.. _pending];
+            _pending.Clear();
+        }
+
+        // Execute buffered actions directly — we are on the UI thread
+        foreach (var action in drained)
+            action();
+    }
+
+    private void RunOnUI(Action action)
+    {
+        lock (_lock)
+        {
+            if (!_uiReady)
+            {
+                _pending.Enqueue(action);
+                return;
+            }
+        }
+
+        Dispatcher.UIThread.Post(action);
+    }
+
+    public void ShowProfileNotification(string profileName) =>
+        RunOnUI(() => _overlayWindow?.ShowNotification(profileName));
+
+    public void UpdateActiveProfile(string profileName) =>
+        RunOnUI(() => _trayIconManager?.UpdateActiveProfile(profileName));
+
+    public void SetAvailableProfiles(IReadOnlyList<string> profileNames) =>
+        RunOnUI(() => _trayIconManager?.SetAvailableProfiles(profileNames));
+}

--- a/src/ArcadeCabinetSwitcher/UI/IOverlayService.cs
+++ b/src/ArcadeCabinetSwitcher/UI/IOverlayService.cs
@@ -1,0 +1,10 @@
+namespace ArcadeCabinetSwitcher.UI;
+
+public interface IOverlayService
+{
+    void ShowProfileNotification(string profileName);
+    void UpdateActiveProfile(string profileName);
+    void SetAvailableProfiles(IReadOnlyList<string> profileNames);
+    event EventHandler<string>? ProfileSwitchRequested;
+    event EventHandler? ExitRequested;
+}

--- a/src/ArcadeCabinetSwitcher/UI/OverlayWindow.axaml
+++ b/src/ArcadeCabinetSwitcher/UI/OverlayWindow.axaml
@@ -1,0 +1,24 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ArcadeCabinetSwitcher.UI.OverlayWindow"
+        Topmost="True"
+        SystemDecorations="None"
+        Background="Transparent"
+        TransparencyLevelHint="Transparent"
+        CanResize="False"
+        ShowInTaskbar="False"
+        IsVisible="False"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="Manual">
+    <Border Background="#CC000000"
+            CornerRadius="12"
+            Padding="30,15"
+            MinWidth="200">
+        <TextBlock x:Name="ProfileText"
+                   Foreground="White"
+                   FontSize="28"
+                   FontWeight="Bold"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center" />
+    </Border>
+</Window>

--- a/src/ArcadeCabinetSwitcher/UI/OverlayWindow.axaml.cs
+++ b/src/ArcadeCabinetSwitcher/UI/OverlayWindow.axaml.cs
@@ -1,0 +1,47 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+
+namespace ArcadeCabinetSwitcher.UI;
+
+public partial class OverlayWindow : Window
+{
+    private DispatcherTimer? _hideTimer;
+
+    public OverlayWindow()
+    {
+        InitializeComponent();
+    }
+
+    public void ShowNotification(string profileName)
+    {
+        ProfileText.Text = $"Switching to: {profileName}";
+        IsVisible = true;
+
+        // Position after layout pass so Bounds are accurate
+        Dispatcher.UIThread.Post(PositionAtBottomCenter, DispatcherPriority.Render);
+
+        _hideTimer?.Stop();
+        _hideTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+        _hideTimer.Tick += (_, _) =>
+        {
+            IsVisible = false;
+            _hideTimer!.Stop();
+        };
+        _hideTimer.Start();
+    }
+
+    private void PositionAtBottomCenter()
+    {
+        if (Screens?.Primary is not { } screen) return;
+
+        var workArea = screen.WorkingArea;
+        var windowWidth = (int)(Bounds.Width * screen.Scaling);
+        var windowHeight = (int)(Bounds.Height * screen.Scaling);
+
+        var x = workArea.X + (workArea.Width - windowWidth) / 2;
+        var y = workArea.Bottom - windowHeight - (int)(50 * screen.Scaling);
+
+        Position = new PixelPoint(x, y);
+    }
+}

--- a/src/ArcadeCabinetSwitcher/UI/TrayIconManager.cs
+++ b/src/ArcadeCabinetSwitcher/UI/TrayIconManager.cs
@@ -1,0 +1,98 @@
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+
+namespace ArcadeCabinetSwitcher.UI;
+
+public sealed class TrayIconManager : IDisposable
+{
+    private readonly TrayIcon _trayIcon;
+    private readonly NativeMenu _menu;
+    private IReadOnlyList<string> _profileNames = [];
+    private string? _activeProfileName;
+
+    public event EventHandler<string>? ProfileSwitchRequested;
+    public event EventHandler? ExitRequested;
+
+    public TrayIconManager(Application app)
+    {
+        _menu = new NativeMenu();
+
+        _trayIcon = new TrayIcon
+        {
+            ToolTipText = "Arcade Cabinet Switcher",
+            Icon = CreateIcon(),
+            Menu = _menu,
+            IsVisible = true
+        };
+
+        TrayIcon.SetIcons(app, [_trayIcon]);
+
+        RebuildMenu();
+    }
+
+    public void SetAvailableProfiles(IReadOnlyList<string> profileNames)
+    {
+        _profileNames = profileNames;
+        RebuildMenu();
+    }
+
+    public void UpdateActiveProfile(string profileName)
+    {
+        _activeProfileName = profileName;
+        RebuildMenu();
+    }
+
+    private void RebuildMenu()
+    {
+        _menu.Items.Clear();
+
+        foreach (var name in _profileNames)
+        {
+            var capturedName = name;
+            var item = new NativeMenuItem(name)
+            {
+                ToggleType = NativeMenuItemToggleType.CheckBox,
+                IsChecked = string.Equals(name, _activeProfileName, StringComparison.OrdinalIgnoreCase)
+            };
+            item.Click += (_, _) => ProfileSwitchRequested?.Invoke(this, capturedName);
+            _menu.Items.Add(item);
+        }
+
+        if (_profileNames.Count > 0)
+            _menu.Items.Add(new NativeMenuItemSeparator());
+
+        var exitItem = new NativeMenuItem("Exit");
+        exitItem.Click += (_, _) => ExitRequested?.Invoke(this, EventArgs.Empty);
+        _menu.Items.Add(exitItem);
+    }
+
+    private static WindowIcon CreateIcon()
+    {
+        // 16×16 solid blue icon created programmatically — no external asset needed
+        var bitmap = new WriteableBitmap(
+            new PixelSize(16, 16),
+            new Vector(96, 96),
+            PixelFormat.Bgra8888,
+            AlphaFormat.Premul);
+
+        using var frameBuffer = bitmap.Lock();
+        var bytes = new byte[16 * 16 * 4];
+
+        // Blue (BGRA premultiplied: B=0xF5, G=0x87, R=0x42, A=0xFF)
+        for (var i = 0; i < 16 * 16; i++)
+        {
+            bytes[i * 4 + 0] = 0xF5; // B
+            bytes[i * 4 + 1] = 0x87; // G
+            bytes[i * 4 + 2] = 0x42; // R
+            bytes[i * 4 + 3] = 0xFF; // A
+        }
+
+        Marshal.Copy(bytes, 0, frameBuffer.Address, bytes.Length);
+        return new WindowIcon(bitmap);
+    }
+
+    public void Dispose() => _trayIcon.Dispose();
+}

--- a/src/ArcadeCabinetSwitcher/Worker.cs
+++ b/src/ArcadeCabinetSwitcher/Worker.cs
@@ -1,6 +1,7 @@
 using ArcadeCabinetSwitcher.Configuration;
 using ArcadeCabinetSwitcher.Input;
 using ArcadeCabinetSwitcher.ProcessManagement;
+using ArcadeCabinetSwitcher.UI;
 
 namespace ArcadeCabinetSwitcher;
 
@@ -9,7 +10,8 @@ public class Worker(
     IConfigurationLoader configurationLoader,
     IInputHandler inputHandler,
     IProcessManager processManager,
-    ISystemActionHandler systemActionHandler) : BackgroundService
+    ISystemActionHandler systemActionHandler,
+    IOverlayService overlayService) : BackgroundService
 {
     private string? _activeProfileName;
     private int _switching; // 0 = idle, 1 = in progress
@@ -20,7 +22,12 @@ public class Worker(
 
         var config = configurationLoader.Load();
 
+        overlayService.SetAvailableProfiles(config.Profiles.Select(p => p.Name).ToList());
+
         inputHandler.ProfileSwitchRequested += (_, profileName) =>
+            OnProfileSwitchRequested(profileName, config, stoppingToken);
+
+        overlayService.ProfileSwitchRequested += (_, profileName) =>
             OnProfileSwitchRequested(profileName, config, stoppingToken);
 
         await inputHandler.StartAsync(config, stoppingToken);
@@ -41,6 +48,8 @@ public class Worker(
                     "Launching default profile: {ProfileName}", defaultProfile.Name);
                 await processManager.LaunchProfileAsync(defaultProfile, stoppingToken);
                 _activeProfileName = defaultProfile.Name;
+                overlayService.ShowProfileNotification(defaultProfile.Name);
+                overlayService.UpdateActiveProfile(defaultProfile.Name);
             }
             else
             {
@@ -96,6 +105,8 @@ public class Worker(
             }
 
             _activeProfileName = target.Name;
+            overlayService.ShowProfileNotification(target.Name);
+            overlayService.UpdateActiveProfile(target.Name);
 
             logger.LogInformation(LogEvents.ProfileSwitchCompleted,
                 "Profile switch to '{ProfileName}' completed", profileName);

--- a/tests/ArcadeCabinetSwitcher.Tests/WorkerTests.cs
+++ b/tests/ArcadeCabinetSwitcher.Tests/WorkerTests.cs
@@ -1,6 +1,7 @@
 using ArcadeCabinetSwitcher.Configuration;
 using ArcadeCabinetSwitcher.Input;
 using ArcadeCabinetSwitcher.ProcessManagement;
+using ArcadeCabinetSwitcher.UI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -38,7 +39,8 @@ public class WorkerTests
             new StubConfigurationLoader(config),
             inputHandler,
             processManager,
-            systemActionHandler);
+            systemActionHandler,
+            new NullOverlayService());
     }
 
     // ── startup ───────────────────────────────────────────────────────────────
@@ -188,7 +190,8 @@ public class WorkerTests
             new StubConfigurationLoader(config),
             ih,
             blockingPm,
-            new SpySystemActionHandler());
+            new SpySystemActionHandler(),
+            new NullOverlayService());
 
         using var cts = new CancellationTokenSource();
         await worker.StartAsync(cts.Token);
@@ -310,6 +313,15 @@ public class WorkerTests
             _executedActions.Add(action);
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class NullOverlayService : IOverlayService
+    {
+        public void ShowProfileNotification(string profileName) { }
+        public void UpdateActiveProfile(string profileName) { }
+        public void SetAvailableProfiles(IReadOnlyList<string> profileNames) { }
+        public event EventHandler<string>? ProfileSwitchRequested { add { } remove { } }
+        public event EventHandler? ExitRequested { add { } remove { } }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- **Overlay notification**: semi-transparent dark rounded rectangle shown at the bottom-center of the screen for 3 seconds whenever a profile is launched or switched; timer resets if a new notification arrives while one is showing
- **System tray icon**: context menu lists all profiles (checkmark on active), plus an Exit item that triggers a graceful host shutdown
- **Avalonia UI** (11.2.1) added as the UI framework — keeps the project on `net10.0` (no `-windows` TFM change); CI `dotnet build` / `dotnet test` on `ubuntu-latest` is unaffected since the test project has no Avalonia reference

## Architecture notes

- `IOverlayService` interface keeps Worker and tests decoupled from Avalonia
- `Program.cs` runs `host.StartAsync()` (non-blocking) then blocks on `StartWithClassicDesktopLifetime()` on the main thread; exit and shutdown are wired bidirectionally between the Generic Host lifetime and Avalonia
- `AvaloniaOverlayService` buffers calls made before the UI is ready and replays them on initialization

## Test plan

- [ ] `dotnet build` — compiles without errors or warnings
- [ ] `dotnet test` — all 93 tests pass (pre-existing SDL joystick test unaffected)
- [ ] Manual on Windows: tray icon appears on startup; overlay shown on default profile launch and on each switch; active profile is checked in the menu; Exit stops the app cleanly
- [ ] CI: push triggers ubuntu-latest build + test and both stay green

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)