### PR TITLE
Fix process hanging after tray Exit

### DIFF
--- a/src/ArcadeCabinetSwitcher/Program.cs
+++ b/src/ArcadeCabinetSwitcher/Program.cs
@@ -71,5 +71,6 @@ catch (Exception ex)
 finally
 {
     await host.StopAsync();
+    host.Dispose();          // disposes DI container → SdlJoystickReader.Dispose() → SDL_Quit()
     Log.CloseAndFlush();
 }


### PR DESCRIPTION
## Summary

- Add `host.Dispose()` in the `finally` block of `Program.cs` after `host.StopAsync()`
- This disposes the DI container, which calls `SdlJoystickReader.Dispose()` → `SDL_Quit()`, terminating SDL's joystick background thread
- Without this, the thread was a foreground thread keeping the process alive after `Main()` returned

## Test plan

- [ ] Build: `dotnet build`
- [ ] Run: `dotnet run --project src/ArcadeCabinetSwitcher`
- [ ] Right-click tray icon → Exit
- [ ] Confirm process is no longer present in Task Manager

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)