### PR TITLE
Fix process hang on Exit — clear Avalonia sync context before awaiting host stop

### DIFF
--- a/src/ArcadeCabinetSwitcher/Program.cs
+++ b/src/ArcadeCabinetSwitcher/Program.cs
@@ -70,6 +70,7 @@ catch (Exception ex)
 }
 finally
 {
+    SynchronizationContext.SetSynchronizationContext(null);  // clear dead Avalonia dispatcher to prevent await deadlock
     await host.StopAsync();
     host.Dispose();          // disposes DI container → SdlJoystickReader.Dispose() → SDL_Quit()
     Log.CloseAndFlush();


### PR DESCRIPTION
## Summary

- Clears the `SynchronizationContext` at the start of the `finally` block in `Program.cs` before `await host.StopAsync()`
- Avalonia leaves a dead `DispatcherSynchronizationContext` on the UI thread after `StartWithClassicDesktopLifetime` returns; awaiting on it deadlocks, preventing `host.Dispose()` and `SDL_Quit()` from ever being called
- SDL's foreground joystick thread then keeps the process alive indefinitely

## Root cause

```
StartWithClassicDesktopLifetime(...)  // returns, but dead sync context remains on thread
finally {
    await host.StopAsync();           // continuation posted to dead Avalonia dispatcher → deadlock
    host.Dispose();                   // never reached → SDL_Quit() never called
    Log.CloseAndFlush();
}
```

## Fix

```csharp
finally
{
    SynchronizationContext.SetSynchronizationContext(null);  // clear dead dispatcher
    await host.StopAsync();
    host.Dispose();
    Log.CloseAndFlush();
}
```

## Test plan

- [ ] Build: `dotnet build`
- [ ] Run: `dotnet run --project src/ArcadeCabinetSwitcher`
- [ ] Click Exit in the tray icon
- [ ] Verify process disappears from Task Manager within a few seconds
- [ ] Run tests: `dotnet test`

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)