### PR TITLE
Fix flaky delay test — add 50ms tolerance for OS timer imprecision

### DIFF
--- a/tests/ArcadeCabinetSwitcher.Tests/ProcessManagerTests.cs
+++ b/tests/ArcadeCabinetSwitcher.Tests/ProcessManagerTests.cs
@@ -192,8 +192,8 @@ public class ProcessManagerTests
         sw.Stop();
 
         Assert.AreEqual(2, launcher.Launched.Count);
-        Assert.IsTrue(sw.Elapsed >= TimeSpan.FromSeconds(1),
-            $"Expected at least 1s delay but elapsed was {sw.Elapsed}");
+        Assert.IsTrue(sw.Elapsed >= TimeSpan.FromMilliseconds(950),
+            $"Expected at least ~1s delay but elapsed was {sw.Elapsed}");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- `Task.Delay(1s)` can return slightly early due to OS timer resolution, causing the `>= 1s` assertion to fail intermittently in CI (observed elapsed: `00:00:00.9999276`)
- Loosens the assertion to `>= 950ms` to accommodate this imprecision while still verifying the delay is roughly correct

## Test plan
- [ ] `dotnet test` — all tests pass
- [ ] `dotnet test --filter "LaunchProfileAsync_CommandWithDelay_DelaysBeforeLaunch"` — passes consistently

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)