### PR TITLE
Fix scheduled task registration failing with Access Denied

### DIFF
--- a/installer/ArcadeCabinetSwitcher.Installer/Create-ScheduledTask.ps1
+++ b/installer/ArcadeCabinetSwitcher.Installer/Create-ScheduledTask.ps1
@@ -1,7 +1,7 @@
 param([string]$InstallDir)
 $exe = Join-Path $InstallDir 'ArcadeCabinetSwitcher.exe'
 $a = New-ScheduledTaskAction -Execute $exe
-$t = New-ScheduledTaskTrigger -AtLogOn
+$t = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
 $s = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -Hidden
 $p = New-ScheduledTaskPrincipal -UserId "$env:USERNAME" -LogonType Interactive -RunLevel Limited
 Register-ScheduledTask ArcadeCabinetSwitcher -Action $a -Trigger $t -Settings $s -Principal $p -Force


### PR DESCRIPTION
## Summary

- `New-ScheduledTaskTrigger -AtLogOn` without `-User` creates an all-users logon trigger, which requires admin privileges to register
- Adding `-User $env:USERNAME` scopes the trigger to the current user, which succeeds without elevation
- The `Package.wxs` custom action already uses `Impersonate="yes"`, so `$env:USERNAME` resolves to the installing user

## Test plan

- [ ] Run `.\Create-ScheduledTask.ps1 -InstallDir <path>` without elevation and confirm it succeeds
- [ ] Verify task exists: `schtasks /Query /TN "ArcadeCabinetSwitcher" /V /FO LIST`
- [ ] Build and run the MSI installer, confirm scheduled task is created without UAC prompt

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)