### PR TITLE
Add explicit permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build and Test


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` to `.github/workflows/ci.yml`
- Restricts `GITHUB_TOKEN` to the minimum required for checkout, build, and test

## Test plan
- [ ] CI passes on this PR
- [ ] Code scanning alert #2 is resolved after merge

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)